### PR TITLE
Idee voor de kleuren

### DIFF
--- a/MandelbrotC/MandelbrotC.cs
+++ b/MandelbrotC/MandelbrotC.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Runtime.ConstrainedExecution;
 using System.Windows.Forms;
 
+
 int n = 100; //depth
 double scale = 0.01; //smaller number means more zoom
 Point center = new Point(200, 200); //transposes the bitmap to have this point in the center
@@ -25,9 +26,21 @@ Color in_set(double x,double y) //checkt voor elk input punt wat het mandel geta
         b = 2 * copy_a * b + y;
         i++;
     }
-    if (i % 2 == 0)
-        return Color.Black;
-    else return Color.White;
+
+    int red = Convert.ToInt32(255 * i * 2 / n);
+    if (red > 255) red = 255;
+    int green = Convert.ToInt32(255 * i * 3 / n);
+    if (green > 255) green = 255;
+    int blue =  Convert.ToInt32(255 * i * 4 / n);
+    if (blue > 255) blue = 255;
+
+    return Color.FromArgb(255 - red, 255 - green, 255 - blue);
+
+    // Ik heb alle berekeningen buiten FromArgb gebracht. Deze neemt alleen ints dus bijv 255 * 0,7 werkt niet.
+    // De 255, 255, 255 is wit dus ik heb het geinvert. De formules erboven geven altijd een waarde tussen 0 en 255
+    // de kleuren kunnen niet boven 255, dus kan vermenigvuldigd worden voor ander kleurenspectrum.
+    // Focussen op zoom functie, uitgezoomed zinn er simpelweg weinig kleuren te zien.
+
 }
 Bitmap plaatje() //maakt bitmap, gebruikt vorige functie om kleur te bepalen
 {


### PR DESCRIPTION
Heb een systeem bedacht dat lijkt te werken. Er staat in de comments bij wat het stukje doet. In het kort, de kleuren worden buiten de FromArgb berekend om geen probleem te krijgen met doubles in de formule. Elke kleur is heeft een cap van 255. zodat de waardes vermenigvuldigd kunnen worden zonder probleem. 

De n-waarde en de vermigvuldigingswaardes hebben veel invloed up de kleur. Na wat testen merkte ik  dat de meeste kleuren worden weergegeven tussen i = 1 en = 15 als hij helemaal is uitgezoomd. Voor meer variatie moeten we dus eigenlijk meer inzoomen.